### PR TITLE
Add Unity dialogue playback scaffold

### DIFF
--- a/Assets/Resources/episode.json
+++ b/Assets/Resources/episode.json
@@ -1,0 +1,41 @@
+{
+  "episode": {
+    "id": "ep001",
+    "title": "The Mark of Initiation",
+    "characters": [],
+    "scenes": [
+      {
+        "id": "s0_prologue",
+        "lines": [
+          { "char": "leo", "tts": "Fuckin’ rain. Always the goddamn rain.", "anim": "idle_brooding", "fx": "rain_sound" },
+          { "char": "nova", "tts": "Atmospheric moisture at 98%. Air quality reads ozone, grade-B concrete dust, and a high concentration of manufactured apathy.", "anim": "idle_scan", "fx": "scan_ui" }
+        ],
+        "choice": { "timeout_sec": 0, "prompt_caption": "", "options": [ { "id": "continue", "caption": "Continue", "goto": "s1_rooftop" } ] }
+      },
+      {
+        "id": "s1_rooftop",
+        "lines": [
+           { "char": "leo", "tts": "From this moment on, it’s fire over fear. That’s the first command. That’s the only command. We are the signal now.", "anim": "declaration", "fx": "power_surge" }
+        ],
+        "choice": {
+          "timeout_sec": 15,
+          "prompt_caption": "What is the first move?",
+          "options": [
+            { "id": "opt1_broadcast", "caption": "Broadcast the truth on their frequencies.", "goto": "s2_broadcast" },
+            { "id": "opt1_stealth", "caption": "Go dark. Build strength in secret.", "goto": "s2_stealth" }
+          ]
+        }
+      },
+      {
+        "id": "s2_broadcast",
+        "lines": [ { "char": "leo", "tts": "It's time the whole city heard a new song.", "anim": "determined", "fx": "none" } ],
+        "choice": { "options": [ { "id": "continue", "caption": "To Be Continued...", "goto": "ep001_end" } ] }
+      },
+      {
+        "id": "s2_stealth",
+        "lines": [ { "char": "leo", "tts": "Alright. We'll play in the shadows... for now.", "anim": "conspiratorial", "fx": "none" } ],
+        "choice": { "options": [ { "id": "continue", "caption": "To Be Continued...", "goto": "ep001_end" } ] }
+      }
+    ]
+  }
+}

--- a/Assets/Scripts/ChoiceOverlay.cs
+++ b/Assets/Scripts/ChoiceOverlay.cs
@@ -1,0 +1,77 @@
+// Filename: ChoiceOverlay.cs
+using UnityEngine;
+using UnityEngine.UI;
+using System;
+using System.Collections.Generic;
+
+public class ChoiceOverlay : MonoBehaviour
+{
+    [Header("UI References")]
+    public GameObject choicePanel; // The parent panel for all choice UI
+    public Text promptText;
+    public Button[] optionButtons; // Assign your choice buttons in the inspector
+
+    public event Action<ChoiceOption> OnOptionPicked;
+    public event Action OnChoiceTimeout;
+
+    private Choice currentChoice;
+    private float timeoutTimer;
+
+    void Start()
+    {
+        Hide();
+    }
+
+    void Update()
+    {
+        if (choicePanel.activeSelf && currentChoice != null && currentChoice.timeout_sec > 0)
+        {
+            timeoutTimer -= Time.deltaTime;
+            // TODO: Update a visual timer on the UI
+            if (timeoutTimer <= 0)
+            {
+                OnChoiceTimeout?.Invoke();
+                Hide();
+            }
+        }
+    }
+
+    public void Show(Choice choice)
+    {
+        currentChoice = choice;
+        promptText.text = choice.prompt_caption;
+
+        for (int i = 0; i < optionButtons.Length; i++)
+        {
+            if (i < choice.options.Count)
+            {
+                optionButtons[i].gameObject.SetActive(true);
+                // Update the button text
+                optionButtons[i].GetComponentInChildren<Text>().text = choice.options[i].caption;
+                // Get a local copy of the option for the listener
+                ChoiceOption option = choice.options[i];
+                // Remove any previous listeners and add a new one
+                optionButtons[i].onClick.RemoveAllListeners();
+                optionButtons[i].onClick.AddListener(() => PickOption(option));
+            }
+            else
+            {
+                optionButtons[i].gameObject.SetActive(false);
+            }
+        }
+        
+        timeoutTimer = choice.timeout_sec;
+        choicePanel.SetActive(true);
+    }
+
+    public void Hide()
+    {
+        choicePanel.SetActive(false);
+    }
+
+    private void PickOption(ChoiceOption option)
+    {
+        OnOptionPicked?.Invoke(option);
+        Hide();
+    }
+}

--- a/Assets/Scripts/EpisodeLoader.cs
+++ b/Assets/Scripts/EpisodeLoader.cs
@@ -1,0 +1,93 @@
+// Filename: EpisodeLoader.cs
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+
+// --- Data Structures to match JSON schema ---
+[Serializable]
+public class EpisodeData
+{
+    public Episode episode;
+}
+
+[Serializable]
+public class Episode
+{
+    public string id;
+    public string title;
+    public List<Character> characters;
+    public List<Scene> scenes;
+}
+
+[Serializable]
+public class Character
+{
+    public string id;
+    public string display;
+    public string voice;
+    public string rig;
+}
+
+[Serializable]
+public class Scene
+{
+    public string id;
+    public List<Line> lines;
+    public Choice choice;
+}
+
+[Serializable]
+public class Line
+{
+    public string char_id; // Renamed from 'char' as it's a keyword in C#
+    public string tts;
+    public string anim;
+    public string fx;
+}
+
+[Serializable]
+public class Choice
+{
+    public int timeout_sec;
+    public string prompt_caption;
+    public List<ChoiceOption> options;
+}
+
+[Serializable]
+public class ChoiceOption
+{
+    public string id;
+    public string caption;
+    public string goto_scene; // Renamed from 'goto' as it's a keyword in C#
+}
+
+
+// --- Loader Class ---
+public static class EpisodeLoader
+{
+    public static Episode LoadEpisode(string episodeFileName)
+    {
+        TextAsset jsonFile = Resources.Load<TextAsset>(episodeFileName);
+        if (jsonFile == null)
+        {
+            Debug.LogError($"Failed to load episode file: {episodeFileName}.json. Make sure it's in a Resources folder.");
+            return null;
+        }
+
+        // Unity's JsonUtility has issues with root objects. A simple trick is to rename our fields
+        // to avoid C# keywords and then replace them back before parsing.
+        string jsonText = jsonFile.text;
+        jsonText = jsonText.Replace("\"char\":", "\"char_id\":");
+        jsonText = jsonText.Replace("\"goto\":", "\"goto_scene\":");
+        
+        EpisodeData episodeData = JsonUtility.FromJson<EpisodeData>(jsonText);
+        
+        if (episodeData == null || episodeData.episode == null)
+        {
+            Debug.LogError("Failed to parse episode data from JSON.");
+            return null;
+        }
+
+        return episodeData.episode;
+    }
+}

--- a/Assets/Scripts/LipSyncDriver.cs
+++ b/Assets/Scripts/LipSyncDriver.cs
@@ -1,0 +1,45 @@
+// Filename: LipSyncDriver.cs
+using UnityEngine;
+
+public class LipSyncDriver : MonoBehaviour
+{
+    // Example: Assign a SkinnedMeshRenderer of your character's face
+    public SkinnedMeshRenderer characterFace; 
+    private bool isTalking = false;
+    private float timer = 0f;
+
+    void Update()
+    {
+        // Simple open-close animation when talking
+        if (isTalking)
+        {
+            timer += Time.deltaTime * 10; // Speed of mouth movement
+            float weight = (Mathf.Sin(timer) + 1) / 2 * 100; // Value from 0-100
+            // Assuming blend shape index 0 is for mouth open/close
+            if(characterFace != null)
+                characterFace.SetBlendShapeWeight(0, weight);
+        }
+    }
+
+    // Called by PlayerController when dialogue starts
+    public void StartLipSync()
+    {
+        isTalking = true;
+    }
+
+    // Called by PlayerController when dialogue ends
+    public void StopLipSync()
+    {
+        isTalking = false;
+        timer = 0;
+        // Reset mouth to closed position
+        if(characterFace != null)
+            characterFace.SetBlendShapeWeight(0, 0);
+    }
+
+    // Placeholder for a more advanced system
+    public void ProcessPhonemes(object phonemeData)
+    {
+        Debug.Log("Phoneme data received (not implemented).");
+    }
+}

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,0 +1,165 @@
+// Filename: PlayerController.cs
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq; // Required for Find()
+
+public class PlayerController : MonoBehaviour
+{
+    public enum GameState { LOADING, PLAYING, PAUSED, CHOICE_WAITING, TRANSITION, ENDED }
+    
+    [Header("Component References")]
+    public AudioSource audioSource;
+    public ChoiceOverlay choiceOverlay;
+    public LipSyncDriver lipSyncDriver; // Assign your character's lip-sync driver here
+
+    [Header("Episode Data")]
+    public string episodeFileName = "episode"; // Name of the JSON file in Resources
+    
+    private Episode currentEpisode;
+    private Scene currentScene;
+    private int currentLineIndex;
+    private GameState currentState;
+    private Dictionary<string, Scene> sceneLookup;
+
+    void Start()
+    {
+        // Subscribe to events from the choice overlay
+        choiceOverlay.OnOptionPicked += HandleChoicePicked;
+        choiceOverlay.OnChoiceTimeout += HandleChoiceTimeout;
+        
+        StartCoroutine(SetupEpisode());
+    }
+
+    private IEnumerator SetupEpisode()
+    {
+        SetState(GameState.LOADING);
+        currentEpisode = EpisodeLoader.LoadEpisode(episodeFileName);
+
+        if (currentEpisode != null)
+        {
+            // Create a fast lookup dictionary for scenes by their ID
+            sceneLookup = currentEpisode.scenes.ToDictionary(scene => scene.id, scene => scene);
+            
+            // Start with the first scene
+            currentScene = currentEpisode.scenes[0];
+            currentLineIndex = -1; // Start at -1 to advance to 0 first
+            yield return new WaitForSeconds(1f); // Artificial load time
+            SetState(GameState.PLAYING);
+            StartCoroutine(PlayScene());
+        }
+        else
+        {
+            SetState(GameState.ENDED);
+            Debug.LogError("Episode could not be loaded. Halting playback.");
+        }
+    }
+
+    private IEnumerator PlayScene()
+    {
+        // Hide choice UI when a new scene starts
+        choiceOverlay.Hide();
+
+        // Advance to the next line
+        currentLineIndex++;
+        
+        // Check if there are more lines in the current scene
+        if (currentLineIndex < currentScene.lines.Count)
+        {
+            Line line = currentScene.lines[currentLineIndex];
+            
+            // Construct the audio clip ID (matches the SSML generator)
+            string audioId = $"{currentEpisode.id}_{currentScene.id}_l{currentLineIndex:000}";
+            
+            // Load the audio clip from Resources/Audio/
+            AudioClip clip = Resources.Load<AudioClip>($"Audio/{audioId}");
+
+            if (clip)
+            {
+                Debug.Log($"Playing: [{line.char_id}] '{line.tts}'");
+                
+                // Trigger lip-sync and animations (placeholders)
+                lipSyncDriver.StartLipSync(); 
+                // TODO: Trigger animations based on line.anim
+                // TODO: Trigger FX based on line.fx
+
+                audioSource.PlayOneShot(clip);
+                
+                // Wait for the audio clip to finish playing
+                yield return new WaitForSeconds(clip.length);
+
+                lipSyncDriver.StopLipSync();
+
+                // Recursively call this coroutine to play the next line
+                StartCoroutine(PlayScene());
+            }
+            else
+            {
+                Debug.LogError($"AudioClip not found: {audioId}. Make sure it's in 'Resources/Audio/'");
+                // Skip to the next line after a short delay on error
+                yield return new WaitForSeconds(1f);
+                StartCoroutine(PlayScene());
+            }
+        }
+        else
+        {
+            // All lines are finished, check for a choice
+            if (currentScene.choice != null && currentScene.choice.options.Count > 0)
+            {
+                SetState(GameState.CHOICE_WAITING);
+                choiceOverlay.Show(currentScene.choice);
+            }
+            else
+            {
+                // No more lines and no choice, end the episode
+                Debug.Log("End of episode.");
+                SetState(GameState.ENDED);
+            }
+        }
+    }
+
+    private void HandleChoicePicked(ChoiceOption option)
+    {
+        Debug.Log($"Player picked option: {option.caption}, moving to scene: {option.goto_scene}");
+        TransitionToScene(option.goto_scene);
+    }
+    
+    private void HandleChoiceTimeout()
+    {
+        Debug.Log("Choice timed out. Handling default path (first option).");
+        // Default behavior: pick the first option
+        if (currentScene.choice != null && currentScene.choice.options.Count > 0)
+        {
+            TransitionToScene(currentScene.choice.options[0].goto_scene);
+        }
+    }
+
+    private void TransitionToScene(string sceneId)
+    {
+        SetState(GameState.TRANSITION);
+        
+        if (sceneLookup.TryGetValue(sceneId, out Scene nextScene))
+        {
+            currentScene = nextScene;
+            currentLineIndex = -1; // Reset line index for the new scene
+            SetState(GameState.PLAYING);
+            StartCoroutine(PlayScene());
+        }
+        else if (sceneId == "ep001_end")
+        {
+             Debug.Log("End of episode reached via goto target.");
+             SetState(GameState.ENDED);
+        }
+        else
+        {
+            Debug.LogError($"Scene ID not found: {sceneId}. Cannot transition.");
+            SetState(GameState.ENDED);
+        }
+    }
+
+    private void SetState(GameState newState)
+    {
+        currentState = newState;
+        Debug.Log($"Game State changed to: {currentState}");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# FISK-DIMENSION
-"Fisk Dimension – A visionary open-source collective on GitHub, where intellect, artistry, and innovation converge. Only the circled will do. 💯""Fisk Dimension – A visionary open-source collective on GitHub, where intellect, artistry, and innovation converge. Only the circled will do. 💯"
+# FISK DIMENSION – Unity Dialogue Prototype
+
+"Fisk Dimension – A visionary open-source collective on GitHub, where intellect, artistry, and innovation converge. Only the circled will do. 💯"
+
+This repository contains the minimal Unity scaffolding for loading an episode JSON file, playing dialogue audio line-by-line, and presenting branching choices that advance the story. The prototype is intentionally lightweight so it can be dropped into a new Unity project and expanded from there.
+
+## Repository Layout
+
+```
+Assets/
+├── Resources/
+│   ├── Audio/              # Place generated dialogue audio here (e.g. ep001_s0_prologue_l000.wav)
+│   └── episode.json        # Sample episode data for testing
+└── Scripts/
+    ├── ChoiceOverlay.cs    # Handles displaying choices to the player
+    ├── EpisodeLoader.cs    # Loads and deserializes the episode JSON
+    ├── LipSyncDriver.cs    # Simple placeholder lip-sync controller
+    └── PlayerController.cs # Core gameplay loop for dialogue playback
+```
+
+## Unity Setup Instructions
+
+1. **Create the Game Controller**  
+   Add an empty `GameObject` to your scene and rename it `GameController`.
+2. **Attach Scripts**  
+   Add `PlayerController.cs` and `LipSyncDriver.cs` to the `GameController` object.
+3. **Add Audio Source**  
+   Attach an `AudioSource` component to `GameController` and assign it to the `PlayerController`'s **Audio Source** field.
+4. **Create UI Canvas**  
+   In the Hierarchy choose **UI → Canvas** (Unity will also add an `EventSystem`).
+5. **Build the Choice Panel**  
+   - Inside the Canvas, create a **Panel** named `ChoicePanel`.  
+   - Inside `ChoicePanel`, add a **Text** element named `PromptText`.  
+   - Add as many **Button** elements as needed for choices (the sample expects two). Name them `OptionButton1`, `OptionButton2`, etc.
+6. **Wire Up `ChoiceOverlay`**  
+   - Select `ChoicePanel` and add the `ChoiceOverlay.cs` component.  
+   - Assign references in the Inspector: drag `ChoicePanel` into **Choice Panel**, `PromptText` into **Prompt Text**, and your button objects into the **Option Buttons** array.
+7. **Reference the Choice Overlay**  
+   Return to the `GameController`, drag the `ChoicePanel` object into the `PlayerController`'s **Choice Overlay** field, and drag your lip-sync driver component into **Lip Sync Driver**.
+8. **Add Episode Content**  
+   - Leave `Assets/Resources/episode.json` in place for testing or replace it with your own episode file (remember the loader automatically remaps `char`→`char_id` and `goto`→`goto_scene`).  
+   - Drop your generated audio clips into `Assets/Resources/Audio/` using the naming convention `episodeId_sceneId_l###` (e.g. `ep001_s0_prologue_l000`).
+9. **Press Play**  
+   Enter Play Mode. The `PlayerController` loads the JSON episode, plays each audio line sequentially, and displays choices when a scene defines them. Choice selection (or timeout) drives scene transitions.
+
+## Next Steps
+
+- Replace placeholder lip-sync logic with your character animation system.  
+- Trigger rig animations and FX based on the `anim` and `fx` metadata embedded in each line.  
+- Expand the UI to visualize choice timers, player inventory, or relationship meters.
+
+Feel free to adapt and build upon this scaffold as the project evolves.


### PR DESCRIPTION
## Summary
- add serializable episode data structures and loader that remaps reserved JSON fields
- implement PlayerController loop plus UI choice overlay and placeholder lip-sync driver
- provide sample episode JSON, audio folder scaffold, and setup instructions in README

## Testing
- not run (Unity project setup only)

------
https://chatgpt.com/codex/tasks/task_e_68cbb9fdc0c883258e97796a569ab1b2